### PR TITLE
Add script to build LLVM + --with-cmodel=medany swtich

### DIFF
--- a/LLVM_FOR_RISCV.md
+++ b/LLVM_FOR_RISCV.md
@@ -53,7 +53,7 @@ git clone git@github.com:Condor-Performance-Modeling/how-to.git
 
 ### Running the Script
 
-To begin the setup process, navigate to the directory containing the build_llvm.sh script and execute it. This script automates the tasks of downloading, compiling, and installing the LLVM toolchain tailored for RISC-V development. 
+To begin the setup process, navigate to the directory containing the build_llvm.sh script and execute it. This script automates the tasks of downloading, compiling, and installing the LLVM toolchain tailored for RISC-V development.
 
 ```bash
 bash how-to/scripts/build_llvm.sh

--- a/LLVM_FOR_RISCV.md
+++ b/LLVM_FOR_RISCV.md
@@ -42,119 +42,12 @@ successfully deactivated the environments.
 
 # Use script to build LLVM
 
-**Before Running the Script:**
-
-- Ensure you have set the `TOP` environment variable to your desired workspace directory.
-- Confirm that any active `Conda`/`Sparta` environments are deactivated.
-- This script assumes the `RISC-V GNU Toolchain` for Linux is already built and available at `/data/tools/riscv64-unknown-linux-gnu`. If this is not the case, you would need to build or adjust this part accordingly.
-
 **Running the Script:**
 
 ```bash
 cd $TOP
 bash how-to/scripts/build_llvm.sh
 ```
-
-<details>
-  <summary>Details: Building LLVM for Baremetal step by step</summary>
-
-## Directory Setup for Build Files and Installation (Baremetal)
-
-Create a directory for RISC-V files and `_install` directory:
-
-```bash
-cd /data/users/$USER/condor # or your preferred workspace
-mkdir llvm-baremetal
-cd llvm-baremetal
-mkdir _install
-```
-
-## The RISC-V GNU Toolchain for Baremetal
-
-This step compiles the `RISC-V toolchain` for baremetal. It is crucial that you use `--with-cmodel=medany` for this toolchain.
-
-```bash
-git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
-pushd riscv-gnu-toolchain
-./configure --prefix=`pwd`/../_install --enable-multilib --with-cmodel=medany
-make -j 32
-popd
-```
-
-## Cloning and Building LLVM for RISC-V (Baremetal)
-
-Clone the LLVM project and initiate the build:
-
-```bash
-git clone https://github.com/llvm/llvm-project.git riscv-llvm
-pushd riscv-llvm
-ln -s ../../clang llvm/tools || true
-mkdir _build
-cd _build
-cmake -G Ninja -DCMAKE_BUILD_TYPE="Release" \
-  -DBUILD_SHARED_LIBS=True -DLLVM_USE_SPLIT_DWARF=True \
-  -DCMAKE_INSTALL_PREFIX="../../_install" \
-  -DLLVM_OPTIMIZED_TABLEGEN=True -DLLVM_BUILD_TESTS=False \
-  -DDEFAULT_SYSROOT="../../_install/riscv64-unknown-elf" \
-  -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-elf" \
-  -DLLVM_TARGETS_TO_BUILD="RISCV" \
-  -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" \
-  ../llvm
-cmake --build . --target install
-popd
-```
-
-</details>
-
-<details>
-  <summary>Details: Building LLVM for Linux step by step</summary>
-
-## Directory Setup for Build Files and Installation (Linux)
-
-Create a directory for RISC-V files and `_install` directory:
-
-```bash
-cd /data/users/$USER/condor # or your preferred workspace
-mkdir llvm-linux
-cd llvm-linux
-mkdir _install
-```
-
-## The RISC-V GNU Toolchain for Linux
-
-The `RISC-V GNU toolchain` is necessary to use the LLVM, you should be able to find it under `/data/tools/riscv64-unknown-linux-gnu`. Copy it to the `_install` directory in your workspace
-
-```bash
-cp -fa /data/tools/riscv64-unknown-linux-gnu/* _install/
-```
-
-## Cloning and Building LLVM for RISC-V (Linux)
-
-Clone the LLVM project and initiate the build:
-
-```bash
-git clone https://github.com/llvm/llvm-project.git riscv-llvm
-pushd riscv-llvm
-ln -s ../../clang llvm/tools || true
-mkdir _build
-cd _build
-cmake -G Ninja \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=True \
-      -DLLVM_USE_SPLIT_DWARF=True \
-      -DCMAKE_INSTALL_PREFIX="../../_install" \
-      -DLLVM_OPTIMIZED_TABLEGEN=True \
-      -DLLVM_BUILD_TESTS=False \
-      -DDEFAULT_SYSROOT="../../_install/sysroot" \
-      -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
-      -DLLVM_TARGETS_TO_BUILD="RISCV" \
-      -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" \
-      ../llvm
-cmake --build . --target install
-popd
-```
-
-</details>
 
 ## Compiling a Simple C/C++ Program for RISC-V 64-bit
 
@@ -181,3 +74,4 @@ Linux:
 ```bash
 [PATH_TO_YOUR_LLVM_LINUX_INSTALL]/bin/clang --target=riscv64-unknown-linux-gnu -o hello hello.c
 ```
+

--- a/LLVM_FOR_RISCV.md
+++ b/LLVM_FOR_RISCV.md
@@ -42,14 +42,25 @@ successfully deactivated the environments.
 
 # Use script to build LLVM
 
-**Running the Script:**
+## Running the Script
+
+To begin the setup process, navigate to the directory containing the build_llvm.sh script and execute it. This script automates the tasks of downloading, compiling, and installing the LLVM toolchain tailored for RISC-V development. 
 
 ```bash
-cd $TOP
-bash how-to/scripts/build_llvm.sh
+bash build_llvm.sh
 ```
 
-## Compiling a Simple C/C++ Program for RISC-V 64-bit
+## What the Script Does
+
+- *Cloning Required Repositories:* The script starts by cloning the necessary repositories, including the RISC-V GNU Toolchain and the LLVM project. These repositories provide the source code needed to compile the toolchain and LLVM specifically for the RISC-V architecture.
+- *Copying/Compiling RISC-V GNU Toolchain for Baremetal:* Depending on whether a pre-built toolchain is available, the script may copy an existing toolchain or compile a new one for Baremetal development.
+- *Copying/Compiling RISC-V GNU Toolchain for Linux:* Depending on whether a pre-built toolchain is available, the script may copy an existing toolchain or compile a new one for Linux development.
+- *Compiling LLVM for Baremetal:* Next, the script compiles LLVM components for baremetal development. LLVM provides a collection of modular and reusable compiler and toolchain technologies.
+- *Compiling LLVM for Linux:* Finally, the script compiles LLVM for Linux, enabling the development of applications for RISC-V based Linux systems.
+
+Once the script completes successfully, the LLVM toolchain for both baremetal and Linux RISC-V development will be installed in the specified directories.
+
+# Compiling a Simple C/C++ Program for RISC-V 64-bit
 
 Create a source file `hello.c`:
 

--- a/LLVM_FOR_RISCV.md
+++ b/LLVM_FOR_RISCV.md
@@ -61,17 +61,9 @@ int main(){
 }
 ```
 
-**Compile the code:**
-
-Baremetal:
+Compile the code:
 
 ```bash
-[PATH_TO_YOUR_LLVM_BAREMETAL_INSTALL]/bin/clang -march=rv64gc -mabi=lp64d hello.c -o hello
-```
-
-Linux:
-
-```bash
-[PATH_TO_YOUR_LLVM_LINUX_INSTALL]/bin/clang --target=riscv64-unknown-linux-gnu -o hello hello.c
+[PATH_TO_YOUR_LLVM__INSTALL]/bin/clang -march=rv64gc -mabi=lp64d hello.c -o hello
 ```
 

--- a/LLVM_FOR_RISCV.md
+++ b/LLVM_FOR_RISCV.md
@@ -40,7 +40,23 @@ successfully deactivated the environments.
   conda deactivate     # leave base
 ```
 
-# LLVM for Baremetal
+# Use script to build LLVM
+
+**Before Running the Script:**
+
+- Ensure you have set the `TOP` environment variable to your desired workspace directory.
+- Confirm that any active `Conda`/`Sparta` environments are deactivated.
+- This script assumes the `RISC-V GNU Toolchain` for Linux is already built and available at `/data/tools/riscv64-unknown-linux-gnu`. If this is not the case, you would need to build or adjust this part accordingly.
+
+**Running the Script:**
+
+```bash
+cd $TOP
+bash how-to/scripts/build_llvm.sh
+```
+
+<details>
+  <summary>Details: Building LLVM for Baremetal step by step</summary>
 
 ## Directory Setup for Build Files and Installation (Baremetal)
 
@@ -55,13 +71,15 @@ mkdir _install
 
 ## The RISC-V GNU Toolchain for Baremetal
 
-The `RISC-V GNU toolchain` is necessary to use the LLVM, you should be able to find it under `/data/tools/riscv64-unknown-elf`. Copy it to the `_install` directory in your workspace
+This step compiles the `RISC-V toolchain` for baremetal. It is crucial that you use `--with-cmodel=medany` for this toolchain.
 
 ```bash
-cp -fa /data/tools/riscv64-unknown-elf/* _install/
+git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
+pushd riscv-gnu-toolchain
+./configure --prefix=`pwd`/../_install --enable-multilib --with-cmodel=medany
+make -j 32
+popd
 ```
-
-If you don't have the `RISC-V GNU toolchain` ready under `/data/tools/riscv64-unknown-elf`, you can clone and compile it yourself folowing [this section](#cloning-and-building-the-risc-v-gnu-toolchain) instead of copying it.
 
 ## Cloning and Building LLVM for RISC-V (Baremetal)
 
@@ -86,7 +104,10 @@ cmake --build . --target install
 popd
 ```
 
-# LLVM for Linux
+</details>
+
+<details>
+  <summary>Details: Building LLVM for Linux step by step</summary>
 
 ## Directory Setup for Build Files and Installation (Linux)
 
@@ -133,7 +154,9 @@ cmake --build . --target install
 popd
 ```
 
-# Compiling a Simple C/C++ Program for RISC-V 64-bit
+</details>
+
+## Compiling a Simple C/C++ Program for RISC-V 64-bit
 
 Create a source file `hello.c`:
 
@@ -157,16 +180,4 @@ Linux:
 
 ```bash
 [PATH_TO_YOUR_LLVM_LINUX_INSTALL]/bin/clang --target=riscv64-unknown-linux-gnu -o hello hello.c
-```
-
-# Cloning and Building the RISC-V GNU Toolchain
-
-This step compiles the `RISC-V toolchain` for baremetal, which is necessary for the `-DDEFAULT_SYSROOT` setting. If you already have the toolchain files in a different directory, you can skip this step and use that path instead.
-
-```bash
-git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
-pushd riscv-gnu-toolchain
-./configure --prefix=`pwd`/../_install --enable-multilib # adjust to your chosen install path
-make -j 32
-popd
 ```

--- a/LLVM_FOR_RISCV.md
+++ b/LLVM_FOR_RISCV.md
@@ -40,6 +40,16 @@ successfully deactivated the environments.
   conda deactivate     # leave base
 ```
 
+## Clone the Repository
+
+Before running the script, you need to clone the repository containing build_llvm.sh. This repository also includes additional scripts and documentation that might be useful for your development process.
+
+Clone the repository using SSH:
+
+```bash
+git clone git@github.com:Condor-Performance-Modeling/how-to.git
+```
+
 # Use script to build LLVM
 
 ## Running the Script
@@ -47,7 +57,7 @@ successfully deactivated the environments.
 To begin the setup process, navigate to the directory containing the build_llvm.sh script and execute it. This script automates the tasks of downloading, compiling, and installing the LLVM toolchain tailored for RISC-V development. 
 
 ```bash
-bash build_llvm.sh
+bash how-to/scripts/build_llvm.sh
 ```
 
 ## What the Script Does

--- a/LLVM_FOR_RISCV.md
+++ b/LLVM_FOR_RISCV.md
@@ -1,9 +1,8 @@
-
 # Building LLVM on Linux for RISC-V 64-bit Cross-Compilation
 
 This document outlines the steps to build LLVM on a Linux machine for cross-compiling C/C++ code for RISC-V 64-bit.
 
-# Before You Start
+## Before You Start
 
 *This step is optional. All required packages should already be installed for you. If you want to verify this, follow steps below:*
 
@@ -25,7 +24,7 @@ sudo apt -y install \
   libglib2.0-dev libfdt-dev libpixman-1-dev
 ```
 
-## Exit Conda
+### Exit Conda
 
 **You must deactivate the conda environment before building LLVM.**
 
@@ -40,7 +39,7 @@ successfully deactivated the environments.
   conda deactivate     # leave base
 ```
 
-## Clone the Repository
+### Clone the Repository
 
 Before running the script, you need to clone the repository containing build_llvm.sh. This repository also includes additional scripts and documentation that might be useful for your development process.
 
@@ -50,9 +49,9 @@ Clone the repository using SSH:
 git clone git@github.com:Condor-Performance-Modeling/how-to.git
 ```
 
-# Use script to build LLVM
+## Use script to build LLVM
 
-## Running the Script
+### Running the Script
 
 To begin the setup process, navigate to the directory containing the build_llvm.sh script and execute it. This script automates the tasks of downloading, compiling, and installing the LLVM toolchain tailored for RISC-V development. 
 
@@ -60,17 +59,17 @@ To begin the setup process, navigate to the directory containing the build_llvm.
 bash how-to/scripts/build_llvm.sh
 ```
 
-## What the Script Does
+### What the Script Does
 
 - *Cloning Required Repositories:* The script starts by cloning the necessary repositories, including the RISC-V GNU Toolchain and the LLVM project. These repositories provide the source code needed to compile the toolchain and LLVM specifically for the RISC-V architecture.
 - *Copying/Compiling RISC-V GNU Toolchain for Baremetal:* Depending on whether a pre-built toolchain is available, the script may copy an existing toolchain or compile a new one for Baremetal development.
-- *Copying/Compiling RISC-V GNU Toolchain for Linux:* Depending on whether a pre-built toolchain is available, the script may copy an existing toolchain or compile a new one for Linux development.
 - *Compiling LLVM for Baremetal:* Next, the script compiles LLVM components for baremetal development. LLVM provides a collection of modular and reusable compiler and toolchain technologies.
+- *Copying/Compiling RISC-V GNU Toolchain for Linux:* Depending on whether a pre-built toolchain is available, the script may copy an existing toolchain or compile a new one for Linux development.
 - *Compiling LLVM for Linux:* Finally, the script compiles LLVM for Linux, enabling the development of applications for RISC-V based Linux systems.
 
 Once the script completes successfully, the LLVM toolchain for both baremetal and Linux RISC-V development will be installed in the specified directories.
 
-# Compiling a Simple C/C++ Program for RISC-V 64-bit
+## Compiling a Simple C/C++ Program for RISC-V 64-bit
 
 Create a source file `hello.c`:
 
@@ -87,4 +86,3 @@ Compile the code:
 ```bash
 [PATH_TO_YOUR_LLVM__INSTALL]/bin/clang -march=rv64gc -mabi=lp64d hello.c -o hello
 ```
-

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -6,6 +6,12 @@ CURRENT_STEP=""
 COPY_BAREMETAL_TOOLCHAIN=false
 COPY_LINUX_TOOLCHAIN=false
 
+echo_step() {
+    echo
+    echo "Starting Step: $1"
+    echo
+}
+
 pretty_error() {
     echo
     echo -e "\t#### -------------------------------------------------"
@@ -29,7 +35,7 @@ exit_gracefully() {
 #--------------------------------------------------------------------------------------------------------------------------
 
 get_user_input() {
-    echo "Starting Step: Environment Setup"
+    echo_step "Environment Setup"
 
     # Check if Conda environment is active
     if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
@@ -38,9 +44,10 @@ get_user_input() {
     fi
 
     # Ask for install path
-    echo "Starting Step: Install Path Setup"
+    echo_step  "Install Path Setup"
 
     # Ask for the baremetal install path
+    echo
     read -p "Enter the baremetal install path [default is $(pwd)/llvm-baremetal]: " BAREMETAL_INSTALL_PATH
     BAREMETAL_INSTALL_PATH=${BAREMETAL_INSTALL_PATH:-$(pwd)/llvm-baremetal}
 
@@ -51,6 +58,7 @@ get_user_input() {
     fi
 
     # Ask for the Linux install path
+    echo
     read -p "Enter the Linux install path [default is $(pwd)/llvm-linux]: " LINUX_INSTALL_PATH
     LINUX_INSTALL_PATH=${LINUX_INSTALL_PATH:-$(pwd)/llvm-linux}
 
@@ -63,6 +71,7 @@ get_user_input() {
     # Confirm installation paths with the user
     echo "LLVM Baremetal will be installed at: $BAREMETAL_INSTALL_PATH"
     echo "LLVM Linux will be installed at: $LINUX_INSTALL_PATH"
+    echo
     read -p "Do you wish to continue with these paths? [Y/n]: " confirm_paths
     if [[ ! "$confirm_paths" =~ ^([yY][eE][sS]|[yY])$ ]] && [ -n "$confirm_paths" ]; then
         pretty_error "User aborted the LLVM setup process."
@@ -75,7 +84,8 @@ get_user_input() {
     mkdir -p "$LINUX_INSTALL_PATH" || { pretty_error "Failed to create the Linux directory at $LINUX_INSTALL_PATH."; exit 1; }
 
     # Ask for source path
-    echo "Starting Step: Source Path Setup"
+    echo_step  "Source Path Setup"
+    echo
     read -p "Enter the source directory path [default is $(pwd)]: " SOURCE_DIR
     SOURCE_DIR=${SOURCE_DIR:-$(pwd)}
 
@@ -83,6 +93,7 @@ get_user_input() {
 
     # Check for pre-built RISC-V GNU Toolchain for Baremetal
     if [ -d "/data/tools/riscv64-unknown-elf" ]; then
+        echo
         echo "Found pre-built RISC-V GNU Toolchain for Baremetal."
         echo "Please ensure that the existing toolchain was built using --with-cmodel=medany."
         read -p "Do you want to use the pre-built toolchain? [Y/n]: " use_prebuilt_baremetal
@@ -93,6 +104,7 @@ get_user_input() {
 
     # Check for pre-built RISC-V GNU Toolchain for Linux
     if [ -d "/data/tools/riscv64-unknown-linux-gnu" ]; then
+        echo
         echo "Found pre-built RISC-V GNU Toolchain for Linux."
         echo "Please ensure that the existing toolchain was built using --with-cmodel=medany."
         read -p "Do you want to use the pre-built toolchain? [Y/n]: " use_prebuilt_linux
@@ -102,7 +114,8 @@ get_user_input() {
     fi
 
     # Confirm start of LLVM setup process
-    echo "Starting Step: LLVM Setup Process"
+    echo_step "LLVM Setup Process"
+    echo
     read -p "The LLVM setup process might take some time. Do you wish to start the process? [Y/n]: " start_setup
     if [[ ! "$start_setup" =~ ^([yY][eE][sS]|[yY])$ ]] && [ -n "$start_setup" ]; then
         pretty_error "User aborted the LLVM setup process."
@@ -114,8 +127,7 @@ get_user_input() {
 
 # Function to clone the required repositories
 clone_repositories() {
-    CURRENT_STEP="Cloning repositories"
-    echo "Starting Step: $CURRENT_STEP"
+    echo_step "Cloning repositories"
 
     cd "$SOURCE_DIR" || { echo "Failed to change directory to SOURCE_DIR."; exit 1; }
 
@@ -140,8 +152,7 @@ clone_repositories() {
 
 # Function to copy or compile the RISC-V GNU Toolchain for Baremetal
 compile_or_copy_riscv_gnu_toolchain_baremetal() {
-    CURRENT_STEP="Setting up RISC-V GNU Toolchain for Baremetal"
-    echo "Starting Step: $CURRENT_STEP"
+    echo_step "Setting up RISC-V GNU Toolchain for Baremetal"
 
     if [ "$COPY_BAREMETAL_TOOLCHAIN" = true ]; then
         echo "Copying the RISC-V GNU Toolchain for Baremetal..."
@@ -157,8 +168,7 @@ compile_or_copy_riscv_gnu_toolchain_baremetal() {
 
 # Function to copy or compile RISC-V GNU Toolchain for Linux
 compile_or_copy_riscv_gnu_toolchain_linux() {
-    CURRENT_STEP="Setting up RISC-V GNU Toolchain for Linux"
-    echo "Starting Step: $CURRENT_STEP"
+    echo_step "Setting up RISC-V GNU Toolchain for Linux"
 
     if [ "$COPY_LINUX_TOOLCHAIN" = true ]; then
         echo "Copying the RISC-V GNU Toolchain for Linux..."
@@ -174,8 +184,7 @@ compile_or_copy_riscv_gnu_toolchain_linux() {
 
 # Function to compile LLVM for Baremetal
 compile_llvm_baremetal() {
-    CURRENT_STEP="Compiling LLVM for Baremetal"
-    echo "Starting Step: $CURRENT_STEP"
+    echo_step "Compiling LLVM for Baremetal"
 
     cd "$SOURCE_DIR/riscv-llvm" || { echo "Failed to change directory to riscv-llvm."; exit 1; }
     rm -rf _build || { echo "Failed to remove previous build directory."; exit 1; }
@@ -195,8 +204,7 @@ compile_llvm_baremetal() {
 
 # Function to compile LLVM for Linux
 compile_llvm_linux() {
-    CURRENT_STEP="Compiling LLVM for Linux"
-    echo "Starting Step: $CURRENT_STEP"
+    echo_step "Compiling LLVM for Linux"
 
     cd "$SOURCE_DIR/riscv-llvm" || { echo "Failed to change directory to riscv-llvm."; exit 1; }
     rm -rf _build || { echo "Failed to remove previous build directory."; exit 1; }

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -1,127 +1,237 @@
 #!/bin/bash
 
-if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
-    echo "Conda environment is active. Please deactivate Conda and/or Sparta before continuing."
-    exit 1
-fi
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_FILE="${TIMESTAMP}_cmp_env_setup.log"
+CURRENT_STEP=""
+COPY_BAREMETAL_TOOLCHAIN=false
+COPY_LINUX_TOOLCHAIN=false
 
-if [ -z "$TOP" ] || [ ! -d "$TOP" ]; then
-    echo "The TOP variable is not set to a valid directory."
-    echo "To set the required environment variables, cd into your work area and run: source how-to/env/setuprc.sh"
-    exit 1
-fi
+pretty_error() {
+    echo
+    echo -e "\t#### -------------------------------------------------"
+    echo -e "\t#### $1"
+    echo -e "\t#### -------------------------------------------------"
+    echo
+}
 
-read -p "Enter the install path [default is $TOP]: " INSTALL_PATH
-INSTALL_PATH=${INSTALL_PATH:-$TOP}
-
-if [ -d "$INSTALL_PATH/llvm" ]; then
-    echo "Install path already exists. Exiting."
-    exit 1
-else
-    mkdir -p "$INSTALL_PATH/llvm" || { echo "Failed to create install path. Exiting."; exit 1; }
-    mkdir -p "$INSTALL_PATH/llvm/llvm-baremetal" || { echo "Failed to create llvm-baremetal directory. Exiting."; exit 1; }
-    mkdir -p "$INSTALL_PATH/llvm/llvm-linux" || { echo "Failed to create llvm-linux directory. Exiting."; exit 1; }
-    echo "Using install path: $INSTALL_PATH"
-fi
-
-read -p "Enter the source directory path [default is $TOP]: " SOURCE_DIR
-SOURCE_DIR=${SOURCE_DIR:-$TOP}
-
-if [ -d "$SOURCE_DIR/llvm_source" ]; then
-    echo "Source directory already exists. Exiting."
-    exit 1
-else
-    mkdir -p "$SOURCE_DIR/llvm_source" || { echo "Failed to create source directory. Exiting."; exit 1; }
-    echo "Using source directory: $SOURCE_DIR/llvm_source"
-fi
-
-cd "$SOURCE_DIR/llvm_source" || exit
-
-if [ ! -d "riscv-gnu-toolchain" ]; then
-    echo "Cloning the RISC-V GNU Toolchain..."
-    git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
-fi
-
-if [ ! -d "llvm-project" ]; then
-    echo "Cloning LLVM project..."
-    git clone https://github.com/llvm/llvm-project.git riscv-llvm
-    cd riscv-llvm || exit
-    ln -s ../../clang llvm/tools || true
-fi
-
-cd "$INSTALL_PATH/llvm/llvm-baremetal" || exit
-echo "Setting up directories for LLVM Baremetal..."
-mkdir -p _install
-
-echo "Compiling RISC-V GNU Toolchain for Baremetal..."
-cd "$SOURCE_DIR/llvm_source/riscv-gnu-toolchain" || exit
-make clean
-./configure --prefix="$INSTALL_PATH/llvm/llvm-baremetal/_install" --enable-multilib --with-cmodel=medany
-make -j $(nproc)
-
-echo "Compiling LLVM for Baremetal..."
-cd "$SOURCE_DIR/llvm_source/riscv-llvm" || exit
-rm -rf _build
-mkdir _build
-cd _build || exit
-cmake -G Ninja -DCMAKE_BUILD_TYPE="Release" \
-  -DBUILD_SHARED_LIBS=True -DLLVM_USE_SPLIT_DWARF=True \
-  -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH/llvm/llvm-baremetal/_install" \
-  -DLLVM_OPTIMIZED_TABLEGEN=True -DLLVM_BUILD_TESTS=False \
-  -DDEFAULT_SYSROOT="$INSTALL_PATH/llvm/llvm-baremetal/_install/riscv64-unknown-elf" \
-  -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-elf" \
-  -DLLVM_TARGETS_TO_BUILD="RISCV" \
-  -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" \
-  ../llvm
-cmake --build . --target install
-
-cd "$INSTALL_PATH/llvm/llvm-linux" || exit
-echo "Setting up directories for LLVM Linux..."
-mkdir -p _install
-
-compile_linux_toolchain=false
-
-if [ -d "/data/tools/riscv64-unknown-linux-gnu" ]; then
-    echo "Found pre-built RISC-V GNU Toolchain for Linux."
-    read -p "Do you want to use the pre-built toolchain? [Y/n]: " use_prebuilt
-
-    if [[ "$use_prebuilt" =~ ^([yY][eE][sS]|[yY])$ ]] || [ -z "$use_prebuilt" ]; then
-        echo "Copying the RISC-V GNU Toolchain for Linux..."
-        cp -fa /data/tools/riscv64-unknown-linux-gnu/* _install/
+exit_gracefully() {
+    trap - EXIT
+    
+    if [[ -n $CURRENT_STEP ]]; then
+        pretty_error "An error occurred during $CURRENT_STEP step."
     else
-      compile_linux_toolchain=true
+        pretty_error "An unexpected error occurred."
     fi
-else
-    compile_linux_toolchain=true
-fi
 
-if [ "$compile_linux_toolchain" = true ]; then
-    echo "Compiling RISC-V GNU Toolchain for Linux from source..."
-    cd "$SOURCE_DIR/llvm_source/riscv-gnu-toolchain" || exit
-    make clean
-    ./configure --prefix="$INSTALL_PATH/llvm/llvm-linux/_install" --with-arch=rv64gc --with-abi=lp64d --enable-linux
-    make linux -j $(nproc)
-fi
+    exit 1
+}
 
-echo "Compiling LLVM for Linux..."
-cd "$SOURCE_DIR/llvm_source/riscv-llvm" || exit
-rm -rf _build
-mkdir _build
-cd _build || exit
-cmake -G Ninja \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=True \
-      -DLLVM_USE_SPLIT_DWARF=True \
-      -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH/llvm/llvm-linux/_install" \
-      -DLLVM_OPTIMIZED_TABLEGEN=True \
-      -DLLVM_BUILD_TESTS=False \
-      -DDEFAULT_SYSROOT="$INSTALL_PATH/llvm/llvm-linux/_install/sysroot" \
-      -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
+#--------------------------------------------------------------------------------------------------------------------------
+
+get_user_input() {
+    echo "Starting Step: Environment Setup"
+
+    # Check if Conda environment is active
+    if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
+        pretty_error "Conda environment is active. Please deactivate Conda and/or Sparta before continuing."
+        exit 1
+    fi
+
+    # Ask for install path
+    echo "Starting Step: Install Path Setup"
+
+    # Ask for the baremetal install path
+    read -p "Enter the baremetal install path [default is $(pwd)/llvm-baremetal]: " BAREMETAL_INSTALL_PATH
+    BAREMETAL_INSTALL_PATH=${BAREMETAL_INSTALL_PATH:-$(pwd)/llvm-baremetal}
+
+    # Check if the baremetal install path already contains LLVM directories
+    if [ -d "$BAREMETAL_INSTALL_PATH" ] && [ "$(ls -A "$BAREMETAL_INSTALL_PATH")" ]; then
+        pretty_error "Baremetal install path already contains LLVM directories."
+        exit 1
+    fi
+
+    # Ask for the Linux install path
+    read -p "Enter the Linux install path [default is $(pwd)/llvm-linux]: " LINUX_INSTALL_PATH
+    LINUX_INSTALL_PATH=${LINUX_INSTALL_PATH:-$(pwd)/llvm-linux}
+
+    # Check if the Linux install path already contains LLVM directories
+    if [ -d "$LINUX_INSTALL_PATH" ] && [ "$(ls -A "$LINUX_INSTALL_PATH")" ]; then
+        pretty_error "Linux install path already contains LLVM directories."
+        exit 1
+    fi
+
+    # Confirm installation paths with the user
+    echo "LLVM Baremetal will be installed at: $BAREMETAL_INSTALL_PATH"
+    echo "LLVM Linux will be installed at: $LINUX_INSTALL_PATH"
+    read -p "Do you wish to continue with these paths? [Y/n]: " confirm_paths
+    if [[ ! "$confirm_paths" =~ ^([yY][eE][sS]|[yY])$ ]] && [ -n "$confirm_paths" ]; then
+        pretty_error "User aborted the LLVM setup process."
+        exit 1
+    fi
+
+    # Create directories
+    echo "Creating LLVM directories..."
+    mkdir -p "$BAREMETAL_INSTALL_PATH" || { pretty_error "Failed to create the baremetal directory at $BAREMETAL_INSTALL_PATH."; exit 1; }
+    mkdir -p "$LINUX_INSTALL_PATH" || { pretty_error "Failed to create the Linux directory at $LINUX_INSTALL_PATH."; exit 1; }
+
+    # Ask for source path
+    echo "Starting Step: Source Path Setup"
+    read -p "Enter the source directory path [default is $(pwd)]: " SOURCE_DIR
+    SOURCE_DIR=${SOURCE_DIR:-$(pwd)}
+
+    echo "Sources will be cloned into: $SOURCE_DIR"
+
+    # Check for pre-built RISC-V GNU Toolchain for Baremetal
+    if [ -d "/data/tools/riscv64-unknown-elf" ]; then
+        echo "Found pre-built RISC-V GNU Toolchain for Baremetal."
+        echo "Please ensure that the existing toolchain was built using --with-cmodel=medany."
+        read -p "Do you want to use the pre-built toolchain? [Y/n]: " use_prebuilt_baremetal
+        if [[ "$use_prebuilt_baremetal" =~ ^([yY][eE][sS]|[yY])$ ]] || [ -z "$use_prebuilt_baremetal" ]; then
+            COPY_BAREMETAL_TOOLCHAIN=true
+        fi
+    fi
+
+    # Check for pre-built RISC-V GNU Toolchain for Linux
+    if [ -d "/data/tools/riscv64-unknown-linux-gnu" ]; then
+        echo "Found pre-built RISC-V GNU Toolchain for Linux."
+        echo "Please ensure that the existing toolchain was built using --with-cmodel=medany."
+        read -p "Do you want to use the pre-built toolchain? [Y/n]: " use_prebuilt_linux
+        if [[ "$use_prebuilt_linux" =~ ^([yY][eE][sS]|[yY])$ ]] || [ -z "$use_prebuilt_linux" ]; then
+            COPY_LINUX_TOOLCHAIN=true
+        fi
+    fi
+
+    # Confirm start of LLVM setup process
+    echo "Starting Step: LLVM Setup Process"
+    read -p "The LLVM setup process might take some time. Do you wish to start the process? [Y/n]: " start_setup
+    if [[ ! "$start_setup" =~ ^([yY][eE][sS]|[yY])$ ]] && [ -n "$start_setup" ]; then
+        pretty_error "User aborted the LLVM setup process."
+        exit 1
+    fi
+}
+
+#--------------------------------------------------------------------------------------------------------------------------
+
+# Function to clone the required repositories
+clone_repositories() {
+    CURRENT_STEP="Cloning repositories"
+    echo "Starting Step: $CURRENT_STEP"
+
+    cd "$SOURCE_DIR" || { echo "Failed to change directory to SOURCE_DIR."; exit 1; }
+
+    # Skip cloning riscv-gnu-toolchain if both toolchains are to be copied
+    if ! { [ "$COPY_BAREMETAL_TOOLCHAIN" = true ] && [ "$COPY_LINUX_TOOLCHAIN" = true ]; }; then
+        if [ ! -d "riscv-gnu-toolchain" ]; then
+            echo "Cloning RISC-V GNU Toolchain..."
+            git clone --recursive https://github.com/riscv/riscv-gnu-toolchain || { echo "Failed to clone RISC-V GNU Toolchain."; exit 1; }
+        fi
+    else
+        echo "Skipping cloning RISC-V GNU Toolchain because pre-built toolchains for both Baremetal and Linux will be used."
+    fi
+
+    if [ ! -d "riscv-gnu-toolchain" ]; then
+        echo "Cloning LLVM project..."
+        git clone https://github.com/llvm/llvm-project.git riscv-llvm || { echo "Failed to clone LLVM project."; exit 1; }
+        cd riscv-llvm || { echo "Failed to enter riscv-llvm directory."; exit 1; }
+        ln -s ../../clang llvm/tools || true
+    fi
+}
+
+
+# Function to copy or compile the RISC-V GNU Toolchain for Baremetal
+compile_or_copy_riscv_gnu_toolchain_baremetal() {
+    CURRENT_STEP="Setting up RISC-V GNU Toolchain for Baremetal"
+    echo "Starting Step: $CURRENT_STEP"
+
+    if [ "$COPY_BAREMETAL_TOOLCHAIN" = true ]; then
+        echo "Copying the RISC-V GNU Toolchain for Baremetal..."
+        cp -fa /data/tools/riscv64-unknown-elf/* "$BAREMETAL_INSTALL_PATH/" || { echo "Failed to copy the RISC-V GNU Toolchain for Baremetal."; exit 1; }
+    else
+        echo "Compiling RISC-V GNU Toolchain for Baremetal from source..."
+        cd "$SOURCE_DIR/riscv-gnu-toolchain" || { echo "Failed to change directory to riscv-gnu-toolchain."; exit 1; }
+        make clean || { echo "Failed to clean previous builds."; exit 1; }
+        ./configure --prefix="$BAREMETAL_INSTALL_PATH" --enable-multilib --with-cmodel=medany || { echo "Failed to configure RISC-V GNU Toolchain for Baremetal."; exit 1; }
+        make -j $(nproc) || { echo "Failed to compile RISC-V GNU Toolchain for Baremetal."; exit 1; }
+    fi
+}
+
+# Function to copy or compile RISC-V GNU Toolchain for Linux
+compile_or_copy_riscv_gnu_toolchain_linux() {
+    CURRENT_STEP="Setting up RISC-V GNU Toolchain for Linux"
+    echo "Starting Step: $CURRENT_STEP"
+
+    if [ "$COPY_LINUX_TOOLCHAIN" = true ]; then
+        echo "Copying the RISC-V GNU Toolchain for Linux..."
+        cp -fa /data/tools/riscv64-unknown-linux-gnu/* "$LINUX_INSTALL_PATH/" || { echo "Failed to copy the RISC-V GNU Toolchain for Linux."; exit 1; }
+    else
+        echo "Compiling RISC-V GNU Toolchain for Linux from source..."
+        cd "$SOURCE_DIR/riscv-gnu-toolchain" || { echo "Failed to change directory to riscv-gnu-toolchain."; exit 1; }
+        make clean || { echo "Failed to clean previous builds."; exit 1; }
+        ./configure --prefix="$LINUX_INSTALL_PATH" --with-arch=rv64gc --with-abi=lp64d --enable-linux --enable-multilib --with-cmodel=medany || { echo "Failed to configure RISC-V GNU Toolchain for Linux."; exit 1; }
+        make linux -j $(nproc) || { echo "Failed to compile RISC-V GNU Toolchain for Linux."; exit 1; }
+    fi
+}
+
+# Function to compile LLVM for Baremetal
+compile_llvm_baremetal() {
+    CURRENT_STEP="Compiling LLVM for Baremetal"
+    echo "Starting Step: $CURRENT_STEP"
+
+    cd "$SOURCE_DIR/riscv-llvm" || { echo "Failed to change directory to riscv-llvm."; exit 1; }
+    rm -rf _build || { echo "Failed to remove previous build directory."; exit 1; }
+    mkdir _build || { echo "Failed to create build directory."; exit 1; }
+    cd _build || { echo "Failed to change directory to build directory."; exit 1; }
+    cmake -G Ninja -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=True -DLLVM_USE_SPLIT_DWARF=True \
+      -DCMAKE_INSTALL_PREFIX="$BAREMETAL_INSTALL_PATH" \
+      -DLLVM_OPTIMIZED_TABLEGEN=True -DLLVM_BUILD_TESTS=False \
+      -DDEFAULT_SYSROOT="$BAREMETAL_INSTALL_PATH/riscv64-unknown-elf" \
+      -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-elf" \
       -DLLVM_TARGETS_TO_BUILD="RISCV" \
-      -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" \
-      ../llvm
-cmake --build . --target install
+      -DLLVM_ENABLE_PROJECTS="bolt;clang;clang-tools-extra;compiler-rt;libc;libclc;lld;lldb;mlir;openmp;polly;pstl" \
+      ../llvm || { echo "Failed to configure LLVM for Baremetal."; exit 1; }
+    cmake --build . --target install || { echo "Failed to build LLVM for Baremetal."; exit 1; }
+}
 
-echo "LLVM setup for Baremetal and Linux has been completed."
-echo "LLVM for Baremetal installed at: $INSTALL_PATH/llvm/llvm-baremetal/_install"
-echo "LLVM for Linux installed at: $INSTALL_PATH/llvm/llvm-linux/_install"
+# Function to compile LLVM for Linux
+compile_llvm_linux() {
+    CURRENT_STEP="Compiling LLVM for Linux"
+    echo "Starting Step: $CURRENT_STEP"
+
+    cd "$SOURCE_DIR/riscv-llvm" || { echo "Failed to change directory to riscv-llvm."; exit 1; }
+    rm -rf _build || { echo "Failed to remove previous build directory."; exit 1; }
+    mkdir _build || { echo "Failed to create build directory."; exit 1; }
+    cd _build || { echo "Failed to change directory to build directory."; exit 1; }
+    
+    cmake -G Ninja -DCMAKE_BUILD_TYPE="Release" \
+          -DBUILD_SHARED_LIBS=True -DLLVM_USE_SPLIT_DWARF=True \
+          -DCMAKE_INSTALL_PREFIX="$LINUX_INSTALL_PATH" \
+          -DLLVM_OPTIMIZED_TABLEGEN=True -DLLVM_BUILD_TESTS=False \
+          -DDEFAULT_SYSROOT="$LINUX_INSTALL_PATH/sysroot" \
+          -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
+          -DLLVM_TARGETS_TO_BUILD="RISCV" \
+          -DLLVM_ENABLE_PROJECTS="bolt;clang;clang-tools-extra;compiler-rt;libc;libclc;lld;lldb;mlir;openmp;polly;pstl" \
+          ../llvm || { echo "Failed to configure LLVM for Linux."; exit 1; }
+          
+    cmake --build . --target install || { echo "Failed to build LLVM for Linux."; exit 1; }
+}
+
+#--------------------------------------------------------------------------------------------------------------------------
+
+build_llvm() {
+    get_user_input
+
+    trap exit_gracefully EXIT
+
+    clone_repositories
+    compile_or_copy_riscv_gnu_toolchain_baremetal
+    compile_or_copy_riscv_gnu_toolchain_linux
+    compile_llvm_baremetal
+    compile_llvm_linux
+
+    echo "LLVM setup for Baremetal and Linux has been completed."
+    echo "LLVM for Baremetal installed at: $BAREMETAL_INSTALL_PATH"
+    echo "LLVM for Linux installed at: $LINUX_INSTALL_PATH"
+}
+
+build_llvm "$@" 2>&1 | tee -a "$LOG_FILE"

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -1,81 +1,115 @@
 #!/bin/bash
 
-# Check if Conda/Sparta is deactivated
 if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
     echo "Conda environment is active. Please deactivate Conda and/or Sparta before continuing."
     exit 1
 fi
 
-# Check if $TOP variable is set to a valid directory
 if [ -z "$TOP" ] || [ ! -d "$TOP" ]; then
     echo "The TOP variable is not set to a valid directory."
+    echo "To set the required environment variables, cd into your work area and run: source how-to/env/setuprc.sh"
     exit 1
 fi
 
 echo "Using TOP directory: $TOP"
+echo "Environment check passed."
 
-# Setup for LLVM for Baremetal
-echo "Setting up LLVM for Baremetal..."
-cd "$TOP" || exit
-mkdir -p llvm-baremetal/_install
-cd llvm-baremetal || exit
+mkdir -p "$TOP/llvm_source"
+cd "$TOP/llvm_source" || exit
 
-# Cloning and Building the RISC-V GNU Toolchain for Baremetal
-echo "Cloning the RISC-V GNU Toolchain for Baremetal..."
-git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
-cd riscv-gnu-toolchain || exit
-./configure --prefix="$PWD/../_install" --enable-multilib --with-cmodel=medany
+if [ ! -d "riscv-gnu-toolchain" ]; then
+    echo "Cloning the RISC-V GNU Toolchain..."
+    git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
+fi
+
+if [ ! -d "llvm-project" ]; then
+    echo "Cloning LLVM project..."
+    git clone https://github.com/llvm/llvm-project.git riscv-llvm
+    cd riscv-llvm || exit
+    ln -s ../../clang llvm/tools || true
+fi
+
+read -p "Enter the install path [$TOP]: " INSTALL_PATH
+INSTALL_PATH=${INSTALL_PATH:-$TOP}
+
+echo "Using install path: $INSTALL_PATH"
+
+mkdir -p "$INSTALL_PATH/llvm/llvm-baremetal"
+mkdir -p "$INSTALL_PATH/llvm/llvm-linux"
+
+cd "$INSTALL_PATH/llvm/llvm-baremetal" || exit
+echo "Setting up directories for LLVM Baremetal..."
+mkdir -p _install
+
+echo "Compiling RISC-V GNU Toolchain for Baremetal..."
+cd "$TOP/llvm_source/riscv-gnu-toolchain" || exit
+make clean
+./configure --prefix="$INSTALL_PATH/llvm/llvm-baremetal/_install" --enable-multilib --with-cmodel=medany
 make -j $(nproc)
-cd ..
 
-# Cloning and Building LLVM for RISC-V (Baremetal)
-echo "Cloning LLVM project for RISC-V Baremetal..."
-git clone https://github.com/llvm/llvm-project.git riscv-llvm
-cd riscv-llvm || exit
-ln -s ../../clang llvm/tools || true
+echo "Compiling LLVM for Baremetal..."
+cd "$TOP/llvm_source/riscv-llvm" || exit
+rm -rf _build
 mkdir _build
 cd _build || exit
 cmake -G Ninja -DCMAKE_BUILD_TYPE="Release" \
   -DBUILD_SHARED_LIBS=True -DLLVM_USE_SPLIT_DWARF=True \
-  -DCMAKE_INSTALL_PREFIX="../../_install" \
+  -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH/llvm/llvm-baremetal/_install" \
   -DLLVM_OPTIMIZED_TABLEGEN=True -DLLVM_BUILD_TESTS=False \
-  -DDEFAULT_SYSROOT="../../_install/riscv64-unknown-elf" \
+  -DDEFAULT_SYSROOT="$INSTALL_PATH/llvm/llvm-baremetal/_install/riscv64-unknown-elf" \
   -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-elf" \
   -DLLVM_TARGETS_TO_BUILD="RISCV" \
   -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" \
   ../llvm
 cmake --build . --target install
-cd ../../..
 
-# Setup for LLVM for Linux
-echo "Setting up LLVM for Linux..."
-mkdir -p llvm-linux/_install
-cd llvm-linux || exit
+cd "$INSTALL_PATH/llvm/llvm-linux" || exit
+echo "Setting up directories for LLVM Linux..."
+mkdir -p _install
 
-# Assuming the RISC-V GNU Toolchain for Linux is pre-built and available
-echo "Copying the RISC-V GNU Toolchain for Linux..."
-cp -fa /data/tools/riscv64-unknown-linux-gnu/* _install/
+compile_linux_toolchain=false
 
-# Cloning and Building LLVM for RISC-V (Linux)
-echo "Cloning LLVM project for RISC-V Linux..."
-git clone https://github.com/llvm/llvm-project.git riscv-llvm
-cd riscv-llvm || exit
-ln -s ../../clang llvm/tools || true
+if [ -d "/data/tools/riscv64-unknown-linux-gnu" ]; then
+    echo "Found pre-built RISC-V GNU Toolchain for Linux."
+    read -p "Do you want to use the pre-built toolchain? [Y/n]: " use_prebuilt
+
+    if [[ "$use_prebuilt" =~ ^([yY][eE][sS]|[yY])$ ]] || [ -z "$use_prebuilt" ]; then
+        echo "Copying the RISC-V GNU Toolchain for Linux..."
+        cp -fa /data/tools/riscv64-unknown-linux-gnu/* _install/
+    else
+      compile_linux_toolchain=true
+    fi
+else
+    compile_linux_toolchain=true
+fi
+
+if [ "$compile_linux_toolchain" = true ]; then
+    echo "Compiling RISC-V GNU Toolchain for Linux from source..."
+    cd "$TOP/llvm_source/riscv-gnu-toolchain" || exit
+    make clean
+    ./configure --prefix="$INSTALL_PATH/llvm/llvm-linux/_install" --with-arch=rv64gc --with-abi=lp64d --enable-linux
+    make linux -j $(nproc)
+fi
+
+echo "Compiling LLVM for Linux..."
+cd "$TOP/llvm_source/riscv-llvm" || exit
+rm -rf _build
 mkdir _build
 cd _build || exit
 cmake -G Ninja \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=True \
       -DLLVM_USE_SPLIT_DWARF=True \
-      -DCMAKE_INSTALL_PREFIX="../../_install" \
+      -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH/llvm/llvm-linux/_install" \
       -DLLVM_OPTIMIZED_TABLEGEN=True \
       -DLLVM_BUILD_TESTS=False \
-      -DDEFAULT_SYSROOT="../../_install/sysroot" \
+      -DDEFAULT_SYSROOT="$INSTALL_PATH/llvm/llvm-linux/_install/sysroot" \
       -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
       -DLLVM_TARGETS_TO_BUILD="RISCV" \
       -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" \
       ../llvm
 cmake --build . --target install
-cd ../..
 
+echo "LLVM for Baremetal installed at: $INSTALL_PATH/llvm/llvm-baremetal/_install"
+echo "LLVM for Linux installed at: $INSTALL_PATH/llvm/llvm-linux/_install"
 echo "LLVM setup for Baremetal and Linux has been completed."

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -141,7 +141,7 @@ clone_repositories() {
         echo "Skipping cloning RISC-V GNU Toolchain because pre-built toolchains for both Baremetal and Linux will be used."
     fi
 
-    if [ ! -d "riscv-gnu-toolchain" ]; then
+    if [ ! -d "riscv-llvm" ]; then
         echo "Cloning LLVM project..."
         git clone https://github.com/llvm/llvm-project.git riscv-llvm || { echo "Failed to clone LLVM project."; exit 1; }
         cd riscv-llvm || { echo "Failed to enter riscv-llvm directory."; exit 1; }
@@ -160,7 +160,7 @@ compile_or_copy_riscv_gnu_toolchain_baremetal() {
     else
         echo "Compiling RISC-V GNU Toolchain for Baremetal from source..."
         cd "$SOURCE_DIR/riscv-gnu-toolchain" || { echo "Failed to change directory to riscv-gnu-toolchain."; exit 1; }
-        make clean || { echo "Failed to clean previous builds."; exit 1; }
+        make clean || echo "make clean failed or not configured. Proceeding without cleaning..."
         ./configure --prefix="$BAREMETAL_INSTALL_PATH" --enable-multilib --with-cmodel=medany || { echo "Failed to configure RISC-V GNU Toolchain for Baremetal."; exit 1; }
         make -j $(nproc) || { echo "Failed to compile RISC-V GNU Toolchain for Baremetal."; exit 1; }
     fi
@@ -176,7 +176,7 @@ compile_or_copy_riscv_gnu_toolchain_linux() {
     else
         echo "Compiling RISC-V GNU Toolchain for Linux from source..."
         cd "$SOURCE_DIR/riscv-gnu-toolchain" || { echo "Failed to change directory to riscv-gnu-toolchain."; exit 1; }
-        make clean || { echo "Failed to clean previous builds."; exit 1; }
+        make clean || echo "make clean failed or not configured. Proceeding without cleaning..."
         ./configure --prefix="$LINUX_INSTALL_PATH" --with-arch=rv64gc --with-abi=lp64d --enable-linux --enable-multilib --with-cmodel=medany || { echo "Failed to configure RISC-V GNU Toolchain for Linux."; exit 1; }
         make linux -j $(nproc) || { echo "Failed to compile RISC-V GNU Toolchain for Linux."; exit 1; }
     fi
@@ -243,3 +243,4 @@ build_llvm() {
 }
 
 build_llvm "$@" 2>&1 | tee -a "$LOG_FILE"
+

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Check if Conda/Sparta is deactivated
+if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
+    echo "Conda environment is active. Please deactivate Conda and/or Sparta before continuing."
+    exit 1
+fi
+
+# Check if $TOP variable is set to a valid directory
+if [ -z "$TOP" ] || [ ! -d "$TOP" ]; then
+    echo "The TOP variable is not set to a valid directory."
+    exit 1
+fi
+
+echo "Using TOP directory: $TOP"
+
+# Setup for LLVM for Baremetal
+echo "Setting up LLVM for Baremetal..."
+cd "$TOP" || exit
+mkdir -p llvm-baremetal/_install
+cd llvm-baremetal || exit
+
+# Cloning and Building the RISC-V GNU Toolchain for Baremetal
+echo "Cloning the RISC-V GNU Toolchain for Baremetal..."
+git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
+cd riscv-gnu-toolchain || exit
+./configure --prefix="$PWD/../_install" --enable-multilib --with-cmodel=medany
+make -j $(nproc)
+cd ..
+
+# Cloning and Building LLVM for RISC-V (Baremetal)
+echo "Cloning LLVM project for RISC-V Baremetal..."
+git clone https://github.com/llvm/llvm-project.git riscv-llvm
+cd riscv-llvm || exit
+ln -s ../../clang llvm/tools || true
+mkdir _build
+cd _build || exit
+cmake -G Ninja -DCMAKE_BUILD_TYPE="Release" \
+  -DBUILD_SHARED_LIBS=True -DLLVM_USE_SPLIT_DWARF=True \
+  -DCMAKE_INSTALL_PREFIX="../../_install" \
+  -DLLVM_OPTIMIZED_TABLEGEN=True -DLLVM_BUILD_TESTS=False \
+  -DDEFAULT_SYSROOT="../../_install/riscv64-unknown-elf" \
+  -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-elf" \
+  -DLLVM_TARGETS_TO_BUILD="RISCV" \
+  -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" \
+  ../llvm
+cmake --build . --target install
+cd ../../..
+
+# Setup for LLVM for Linux
+echo "Setting up LLVM for Linux..."
+mkdir -p llvm-linux/_install
+cd llvm-linux || exit
+
+# Assuming the RISC-V GNU Toolchain for Linux is pre-built and available
+echo "Copying the RISC-V GNU Toolchain for Linux..."
+cp -fa /data/tools/riscv64-unknown-linux-gnu/* _install/
+
+# Cloning and Building LLVM for RISC-V (Linux)
+echo "Cloning LLVM project for RISC-V Linux..."
+git clone https://github.com/llvm/llvm-project.git riscv-llvm
+cd riscv-llvm || exit
+ln -s ../../clang llvm/tools || true
+mkdir _build
+cd _build || exit
+cmake -G Ninja \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=True \
+      -DLLVM_USE_SPLIT_DWARF=True \
+      -DCMAKE_INSTALL_PREFIX="../../_install" \
+      -DLLVM_OPTIMIZED_TABLEGEN=True \
+      -DLLVM_BUILD_TESTS=False \
+      -DDEFAULT_SYSROOT="../../_install/sysroot" \
+      -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
+      -DLLVM_TARGETS_TO_BUILD="RISCV" \
+      -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" \
+      ../llvm
+cmake --build . --target install
+cd ../..
+
+echo "LLVM setup for Baremetal and Linux has been completed."

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -89,6 +89,11 @@ get_user_input() {
     read -p "Enter the source directory path [default is $(pwd)]: " SOURCE_DIR
     SOURCE_DIR=${SOURCE_DIR:-$(pwd)}
 
+    if [[ ! -d "$SOURCE_DIR" ]]; then
+        echo "Source directory does not exist, creating it..."
+        mkdir -p "$SOURCE_DIR" || { pretty_error "Failed to create the source directory at $SOURCE_DIR."; exit 1; }
+    fi
+    
     echo "Sources will be cloned into: $SOURCE_DIR"
 
     # Check for pre-built RISC-V GNU Toolchain for Baremetal

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -206,7 +206,7 @@ compile_llvm_baremetal() {
       -DDEFAULT_SYSROOT="$BAREMETAL_INSTALL_PATH/riscv64-unknown-elf" \
       -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-elf" \
       -DLLVM_TARGETS_TO_BUILD="RISCV" \
-      -DLLVM_ENABLE_PROJECTS="bolt;clang;clang-tools-extra;compiler-rt;libc;libclc;lld;lldb;mlir;openmp;polly;pstl" \
+      -DLLVM_ENABLE_PROJECTS="bolt;clang;clang-tools-extra;libclc;lld;lldb;mlir;openmp;polly;pstl" \
       ../llvm || { echo "Failed to configure LLVM for Baremetal."; exit 1; }
     cmake --build . --target install || { echo "Failed to build LLVM for Baremetal."; exit 1; }
 }
@@ -227,7 +227,7 @@ compile_llvm_linux() {
           -DDEFAULT_SYSROOT="$LINUX_INSTALL_PATH/sysroot" \
           -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
           -DLLVM_TARGETS_TO_BUILD="RISCV" \
-          -DLLVM_ENABLE_PROJECTS="bolt;clang;clang-tools-extra;compiler-rt;libc;libclc;lld;lldb;mlir;openmp;polly;pstl" \
+          -DLLVM_ENABLE_PROJECTS="bolt;clang;clang-tools-extra;libclc;lld;lldb;mlir;openmp;polly;pstl" \
           ../llvm || { echo "Failed to configure LLVM for Linux."; exit 1; }
           
     cmake --build . --target install || { echo "Failed to build LLVM for Linux."; exit 1; }
@@ -242,8 +242,8 @@ build_llvm() {
 
     clone_repositories
     compile_or_copy_riscv_gnu_toolchain_baremetal
-    compile_or_copy_riscv_gnu_toolchain_linux
     compile_llvm_baremetal
+    compile_or_copy_riscv_gnu_toolchain_linux
     compile_llvm_linux
 
     echo "LLVM setup for Baremetal and Linux has been completed."

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -246,6 +246,8 @@ build_llvm() {
     compile_or_copy_riscv_gnu_toolchain_linux
     compile_llvm_linux
 
+    trap - EXIT
+    
     echo "LLVM setup for Baremetal and Linux has been completed."
     echo "LLVM for Baremetal installed at: $BAREMETAL_INSTALL_PATH"
     echo "LLVM for Linux installed at: $LINUX_INSTALL_PATH"


### PR DESCRIPTION
2 changes here:

1. I've made building your own toolchain for baremetal mandatory, as you need to use `--with-cmodel=medany` for it to work with benchmarks.

2. I've wrapped this process into a script, that just builds LLVM for both Baremetal and Linux.