### PR TITLE
Update /tools in how-to to with /data/tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,8 +459,8 @@ If necessary create links to the cross compilers
 
 ```
   cd $TOP
-  ln -s /tools/riscv64-unknown-elf
-  ln -s /tools/riscv64-unknown-linux-gnu
+  ln -s /data/tools/riscv64-unknown-elf
+  ln -s /data/tools/riscv64-unknown-linux-gnu
 ```
 
 ## PATH check
@@ -497,11 +497,11 @@ mkdir -p $TOOLS/riscv-linux
 # Double check the links to the cross compilers
 
 if [ ! -L riscv64-unknown-elf ]; then
-  ln -s /tools/riscv64-unknown-elf
+  ln -s /data/tools/riscv64-unknown-elf
 fi
 
 if [ ! -L riscv64-unknown-linux-gnu ]; then
-  ln -s /tools/riscv64-unknown-linux-gnu
+  ln -s /data/tools/riscv64-unknown-linux-gnu
 fi
 
 wget --no-check-certificate -nc \
@@ -646,11 +646,11 @@ cp dromajo $TOOLS/bin/cpm_simpoint_dromajo
 # Sym link the cross compilers
 # -------------------------------------------------------
 if [ ! -L riscv64-unknown-elf ]; then
-  ln -s /tools/riscv64-unknown-elf
+  ln -s /data/tools/riscv64-unknown-elf
 fi
 
 if [ ! -L riscv64-unknown-linux-gnu ]; then
-  ln -s /tools/riscv64-unknown-linux-gnu
+  ln -s /data/tools/riscv64-unknown-linux-gnu
 fi
 
 # -------------------------------------------------------
@@ -736,7 +736,7 @@ cp $TOOLS/riscv-linux/* $CPM_DROMAJO/run
 cp $PATCHES/cpm.boot.cfg  $CPM_DROMAJO/run
 
 cd $CPM_DROMAJO/run
-$TOOLS/bin/cpm_dromajo --ctrlc --stf_essential_mode --stf_priv_modes USHM --stf_trace example.stf boot.cfg
+$TOOLS/bin/cpm_dromajo --ctrlc --stf_priv_modes USHM --stf_trace example.stf boot.cfg
 ```
 
 <!--

--- a/scripts/Delete-me/base_repos.sh
+++ b/scripts/Delete-me/base_repos.sh
@@ -4,11 +4,11 @@ set -e
 # Sym link the cross compilers
 # -------------------------------------------------------
 if [ ! -L riscv64-unknown-elf ]; then
-  ln -s /tools/riscv64-unknown-elf
+  ln -s /data/tools/riscv64-unknown-elf
 fi
 
 if [ ! -L riscv64-unknown-linux-gnu ]; then
-  ln -s /tools/riscv64-unknown-linux-gnu
+  ln -s /data/tools/riscv64-unknown-linux-gnu
 fi
 
 # -------------------------------------------------------

--- a/scripts/build_cpm_repos.sh
+++ b/scripts/build_cpm_repos.sh
@@ -72,11 +72,11 @@ cp dromajo $TOOLS/bin/cpm_simpoint_dromajo
 # Sym link the cross compilers
 # -------------------------------------------------------
 if [ ! -L riscv64-unknown-elf ]; then
-  ln -sfv /tools/riscv64-unknown-elf
+  ln -sfv /data/tools/riscv64-unknown-elf
 fi
 
 if [ ! -L riscv64-unknown-linux-gnu ]; then
-  ln -sfv /tools/riscv64-unknown-linux-gnu
+  ln -sfv /data/tools/riscv64-unknown-linux-gnu
 fi
 
 # -------------------------------------------------------

--- a/scripts/build_linux_collateral.sh
+++ b/scripts/build_linux_collateral.sh
@@ -14,11 +14,11 @@ mkdir -p $TOOLS/riscv-linux
 # Double check the links to the cross compilers
 
 if [ ! -L riscv64-unknown-elf ]; then
-  ln -sfv /tools/riscv64-unknown-elf
+  ln -sfv /data/tools/riscv64-unknown-elf
 fi
 
 if [ ! -L riscv64-unknown-linux-gnu ]; then
-  ln -sfv /tools/riscv64-unknown-linux-gnu
+  ln -sfv /data/tools/riscv64-unknown-linux-gnu
 fi
 
 # Build the kernel

--- a/scripts/cpm_env_setup.sh
+++ b/scripts/cpm_env_setup.sh
@@ -72,19 +72,19 @@ set_up_cpm_environment() {
     if ! check_progress "cross_compilers_and_tools_checked"; then
         echo_stage "Checking /tools for necessary directories and linking cross compilers"
 
-        if [ ! -d "/tools/riscv64-unknown-elf" ]; then
-            pretty_error "The required directory /tools/riscv64-unknown-elf is missing. Please ensure it exists before continuing."
+        if [ ! -d "/data/tools/riscv64-unknown-elf" ]; then
+            pretty_error "The required directory /data/tools/riscv64-unknown-elf is missing. Please ensure it exists before continuing."
             exit 1
         fi
 
-        if [ ! -d "/tools/riscv64-unknown-linux-gnu" ]; then
-            pretty_error "The required directory /tools/riscv64-unknown-linux-gnu is missing. Please ensure it exists before continuing."
+        if [ ! -d "/data/tools/riscv64-unknown-linux-gnu" ]; then
+            pretty_error "The required directory /data/tools/riscv64-unknown-linux-gnu is missing. Please ensure it exists before continuing."
             exit 1
         fi
 
         cd $TOP
-        ln -fs /tools/riscv64-unknown-elf riscv64-unknown-elf
-        ln -fs /tools/riscv64-unknown-linux-gnu riscv64-unknown-linux-gnu
+        ln -fs /data/tools/riscv64-unknown-elf riscv64-unknown-elf
+        ln -fs /data/tools/riscv64-unknown-linux-gnu riscv64-unknown-linux-gnu
         export PATH=$RV_LINUX_TOOLS/bin:$PATH
         export CROSS_COMPILE=riscv64-unknown-linux-gnu-
 


### PR DESCRIPTION
PR for https://sofomo.atlassian.net/browse/CN-86

Tested on randy, it boots dromajo, for running benchmarks, at the end it’s missing some of the .log files:

![image](https://github.com/user-attachments/assets/9f16a38b-9d92-4367-956e-6233ea696a91)

but it doesn’t seem to be related to /tools → /data/tools change