### PR TITLE
Remove top set -e from conda_env_setup.sh

### DIFF
--- a/scripts/conda_env_setup.sh
+++ b/scripts/conda_env_setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 #Contact: Stan Iwan
 #         Sofomo
 #         2024.04.09


### PR DESCRIPTION
Ensure that the set -e at the top of your script does not interfere with the specific fallback command after the failure of create_conda_env.sh