### PR TITLE
Update build_cpm_repos.sh

### DIFF
--- a/scripts/build_cpm_repos.sh
+++ b/scripts/build_cpm_repos.sh
@@ -61,6 +61,9 @@ cmake ..
 make -j$(nproc)
 cp dromajo $TOOLS/bin/cpm_dromajo
 
+# Run regression tests
+make -j$(nproc) regress
+
 # The stf + simpoint version
 cd ..
 mkdir -p build-simpoint; cd build-simpoint


### PR DESCRIPTION
Update build_cpm_repos.sh to build and run Dromajo regression test as part of the environment setup.