### PR TITLE
[CAWS-57] Fixed problem with reinstall on condor env

### DIFF
--- a/scripts/conda_env_setup.sh
+++ b/scripts/conda_env_setup.sh
@@ -59,11 +59,21 @@ set_up_conda_environment() {
     set -e
 
     if [[ $CONDA_EXIT_CODE -ne 0 ]]; then
-        echo "create_conda_env.sh failed, running fallback command"
-        conda env create -f scripts/rendered_safe_environment.yaml || {
-            echo "Fallback conda environment creation failed."
-            exit 1
-        }
+        if conda env list | grep -q 'sparta'; then
+            # If the environment exists, activate it and update it
+            echo "Conda environment 'sparta' already exists, updating."
+            conda env update --file scripts/rendered_safe_environment.yaml --prune || {
+                echo "Updating 'sparta' environment failed."
+                exit 1
+            }
+        else
+            # If the environment does not exist, attempt to create it
+            echo "create_conda_env.sh failed, running fallback command"
+            conda env create -f scripts/rendered_safe_environment.yaml || {
+                echo "Fallback conda environment creation failed."
+                exit 1
+            }
+        fi
     fi
 
     echo "Setup process completed."

--- a/scripts/cpm_env_setup.sh
+++ b/scripts/cpm_env_setup.sh
@@ -173,7 +173,7 @@ set_up_cpm_environment() {
     if ! check_progress "cpm_repos_installed"; then
         echo_stage "Building and Installing CPM Repos"
         cd "${CONDOR_TOP}"
-        if ! bash how-to/scripts/build_cpm_repos.sh; then
+        if ! CPATH="${CONDA_PREFIX}/include" LIBRARY_PATH="${CONDA_PREFIX}/lib" LD_LIBRARY_PATH="${CONDA_PREFIX}/lib" bash how-to/scripts/build_cpm_repos.sh; then
             pretty_error "Failed to install CPM repos. See log: ${LOG_FILE}"
             exit 1
         fi


### PR DESCRIPTION
* At fallback, conda env setup checks if there's 'sparta' env and if yes, just updates it using newly cloned map/scripts/rendered_safe_environment.yaml
* If there's no 'sparta' env, then it uses this yaml as regular fallback command, to set up safe conda env.